### PR TITLE
chore: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+labels: bug
+---
+
+**What happened?**
+
+**What did you expect?**
+
+**How to reproduce**
+
+```ts
+// minimal code to reproduce
+```
+
+**Environment**
+
+- time-travel version:
+- Node version:
+- Runtime (browser/Node/Bun/Deno):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request
+about: Suggest an idea
+labels: enhancement
+---
+
+**What problem does this solve?**
+
+
+**What does the API look like?**
+
+```ts
+// how you'd want to use it
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## What
+
+<!-- Brief description of the change -->
+
+## Why
+
+<!-- What problem does this solve? -->
+
+## How to test
+
+<!-- Steps to verify the change works -->


### PR DESCRIPTION
## What

Adds minimal GitHub templates for bug reports, feature requests, and pull requests.

## Why

Gives contributors a starting point when filing issues or opening PRs.

## How to test

Check the "New Issue" page on GitHub — should show bug report and feature request options.