### PR TITLE
fix: add github environment for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: ENV-Publish-NPM
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Adds the environment reference needed for OIDC trusted publishing to work.