### PR TITLE
fix: remove git plugin from semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx --package semantic-release@25 --package @semantic-release/changelog --package @semantic-release/git semantic-release
+        run: npx --package semantic-release@25 --package @semantic-release/changelog semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,13 +5,6 @@
 		"@semantic-release/release-notes-generator",
 		"@semantic-release/changelog",
 		["@semantic-release/npm", { "pkgRoot": ".", "provenance": true }],
-		[
-			"@semantic-release/git",
-			{
-				"assets": ["package.json", "CHANGELOG.md"],
-				"message": "chore(release): ${nextRelease.version}"
-			}
-		],
 		"@semantic-release/github"
 	]
 }


### PR DESCRIPTION
Drop @semantic-release/git plugin. Version lives in git tags and npm, not in package.json. Avoids branch protection conflicts.