### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-typecheck-build-test.yml
+++ b/.github/workflows/lint-typecheck-build-test.yml
@@ -22,6 +22,8 @@ jobs:
 
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/BiswaViraj/time-travel/security/code-scanning/2](https://github.com/BiswaViraj/time-travel/security/code-scanning/2)

In general, to fix this issue you should add an explicit `permissions` block at the workflow or job level, granting only what the job needs. For a job that just checks out code and runs lint/typecheck/build/test locally, `contents: read` is usually sufficient.

For this specific workflow, the `lint` job already has `permissions: contents: read`. The `validate` job should match this pattern. In `.github/workflows/lint-typecheck-build-test.yml`, under the `validate` job (around line 24), add a `permissions` section with `contents: read`, at the same indentation level as `runs-on:` and `steps:`. No additional imports or methods are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
