### PR TITLE
fix: add base path prefix to docs hero links

### DIFF
--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -6,10 +6,10 @@ hero:
   tagline: Simple and lightweight undo/redo for JavaScript and TypeScript.
   actions:
     - text: Get Started
-      link: /getting-started/
+      link: /time-travel/getting-started/
       icon: right-arrow
     - text: API Reference
-      link: /api/core/
+      link: /time-travel/api/core/
       icon: open-book
       variant: minimal
 ---


### PR DESCRIPTION
## Summary
- Hero action links on the docs homepage were missing the `/time-travel/` base path prefix, causing 404s on GitHub Pages

## Test plan
- [ ] Verify hero "Get Started" and "API Reference" buttons navigate correctly on GitHub Pages