### PR TITLE
fix: highlight active sidebar items in docs

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -8,6 +8,7 @@ export default defineConfig({
 	base: "/time-travel",
 	integrations: [
 		starlight({
+			customCss: ["./src/styles/custom.css"],
 			plugins: [starlightThemeRapide()],
 			sidebar: [
 				{ label: "Getting Started", slug: "getting-started" },
@@ -22,6 +23,11 @@ export default defineConfig({
 					href: "https://github.com/BiswaViraj/time-travel",
 					icon: "github",
 					label: "GitHub",
+				},
+				{
+					href: "https://www.npmjs.com/package/time-travel",
+					icon: "npm",
+					label: "NPM",
 				},
 			],
 			title: "Time Travel",

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -1,4 +1,4 @@
 .sidebar-pane .top-level > li > a[aria-current="page"].large {
-  color: var(--sl-color-text-accent);
-  font-weight: 600;
+	color: var(--sl-color-text-accent);
+	font-weight: 600;
 }

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -1,0 +1,4 @@
+.sidebar-pane .top-level > li > a[aria-current="page"].large {
+  color: var(--sl-color-text-accent);
+  font-weight: 600;
+}


### PR DESCRIPTION
Fixes sidebar not showing active page highlight by targeting the correct rapide theme selectors.